### PR TITLE
Stabilize alerts

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -17,6 +17,8 @@ local cronJob = function(name, schedule, jobSpec) kube._Object('batch/v1', 'Cron
   },
   spec: {
     schedule: schedule,
+    successfulJobsHistoryLimit: 3,
+    failedJobsHistoryLimit: 3,
     jobTemplate: {
       metadata: {
         name: name,

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
@@ -10,6 +10,7 @@ metadata:
   name: backfill-appuio-cloud-loadbalancer
   namespace: appuio-cloud-reporting
 spec:
+  failedJobsHistoryLimit: 3
   jobTemplate:
     metadata:
       labels:
@@ -78,6 +79,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -91,6 +93,7 @@ metadata:
   name: backfill-appuio-cloud-memory
   namespace: appuio-cloud-reporting
 spec:
+  failedJobsHistoryLimit: 3
   jobTemplate:
     metadata:
       labels:
@@ -159,6 +162,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -172,6 +176,7 @@ metadata:
   name: backfill-appuio-cloud-persistent-storage
   namespace: appuio-cloud-reporting
 spec:
+  failedJobsHistoryLimit: 3
   jobTemplate:
     metadata:
       labels:
@@ -240,3 +245,4 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
@@ -10,6 +10,7 @@ metadata:
   name: check-missing
   namespace: appuio-cloud-reporting
 spec:
+  failedJobsHistoryLimit: 3
   jobTemplate:
     metadata:
       labels:
@@ -93,3 +94,4 @@ spec:
               name: sync-categories
           restartPolicy: OnFailure
   schedule: 30 8-14 * * *
+  successfulJobsHistoryLimit: 3

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -10,6 +10,7 @@ metadata:
   name: generate-invoices
   namespace: appuio-cloud-reporting
 spec:
+  failedJobsHistoryLimit: 3
   jobTemplate:
     metadata:
       labels:
@@ -122,3 +123,4 @@ spec:
               resources: {}
           restartPolicy: OnFailure
   schedule: 0 10 1 * *
+  successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Keep more than one failed job in the history so `kube_job_failed` does not flicker between 0 and 1.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
