### PR TITLE
Ensure invoice job is not restarted on failures

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -196,7 +196,15 @@ local invoiceCJ = common.CronJob('generate-invoices', params.schedules.invoice, 
       resources: {},
     },
   ],
-});
+}) {
+  spec+: {
+    jobTemplate+: {
+      spec+: {
+        backoffLimit: 0,
+      },
+    },
+  },
+};
 
 
 // Define outputs below

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/part-of: syn
         cron-job-name: generate-invoices
     spec:
+      backoffLimit: 0
       template:
         metadata:
           labels:


### PR DESCRIPTION
In #5 we tried to disable restarts since the invoice command is not idempotent.

Only setting the restart policy is not enough.
Setting the backoffLimit to zero is also required, otherwise the Job controller
schedules new pods if one fails.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
