### PR TITLE
Add support for suspending CronJobs

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "0f8aa8baef803c2f09d710c717f26f7eff145407",
+  "commit": "2f97ae46dfbf7be5817132be4e1b40ecbf98711a",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "appuio-cloud-reporting",
       "slug": "appuio-cloud-reporting",
       "parameter_key": "appuio_cloud_reporting",
-      "test_cases": "defaults",
+      "test_cases": "defaults suspended-cronjobs",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - suspended-cronjobs
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - suspended-cronjobs
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml
+test_instances = tests/defaults.yml tests/suspended-cronjobs.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -19,6 +19,7 @@ parameters:
       check_missing: '30 8-14 * * *'
       invoice: '0 10 1 * *'
 
+    development_mode: false
     schedules_suspend:
       backfill: false
       check_missing: false

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -19,6 +19,11 @@ parameters:
       check_missing: '30 8-14 * * *'
       invoice: '0 10 1 * *'
 
+    schedules_suspend:
+      backfill: false
+      check_missing: false
+      invoice: false
+
     database:
       host: null
       port: 5432

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -12,7 +12,16 @@ local labels = {
 
 local cronJob = function(name, scheduleName, jobSpec)
   local schedule = params.schedules[scheduleName];
-  local suspend = params.schedules_suspend[scheduleName];
+  local suspend =
+    local s = params.schedules_suspend[scheduleName];
+    if s && !params.development_mode then
+      error (
+        '\n\nSuspending cronjobs not possible unless the component is in development mode.\n'
+        + 'Please note that suspending the cronjobs will partially or completely disable APPUiO Cloud billing.\n'
+        + 'To enable development mode, set parameter `development_mode` to true.\n'
+      )
+    else
+      s;
   kube._Object('batch/v1', 'CronJob', name) {
     metadata+: {
       namespace: params.namespace,

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -19,6 +19,16 @@ local cronJob = function(name, scheduleName, jobSpec)
       labels+: labels,
     },
     spec: {
+      // set startingDeadlineSeconds to ensure that new jobs will be scheduled
+      // if the cronjob is unsuspended after a long period of being suspended.
+      // This is required because any jobs that would have been scheduled
+      // while the CronJob is suspended count as missed and without
+      // startingDeadlineSeconds set, the CronJob controller will not schedule
+      // new jobs if >100 jobs were missed. See the following upstream
+      // documentation:
+      // * https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#suspend
+      // * https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations
+      startingDeadlineSeconds: 180,
       schedule: schedule,
       successfulJobsHistoryLimit: 3,
       failedJobsHistoryLimit: 3,

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -10,36 +10,40 @@ local labels = {
   'app.kubernetes.io/part-of': 'syn',
 };
 
-local cronJob = function(name, schedule, jobSpec) kube._Object('batch/v1', 'CronJob', name) {
-  metadata+: {
-    namespace: params.namespace,
-    labels+: labels,
-  },
-  spec: {
-    schedule: schedule,
-    successfulJobsHistoryLimit: 3,
-    failedJobsHistoryLimit: 3,
-    jobTemplate: {
-      metadata: {
-        labels+: labels {
-          'cron-job-name': name,
-        },
-      },
-      spec: {
-        template: {
-          metadata: {
-            labels+: labels,
-          },
-          spec: {
-            restartPolicy: 'OnFailure',
-            initContainers: [],
-            containers: [],
-          } + jobSpec,
-        },
-      },
+local cronJob = function(name, scheduleName, jobSpec)
+  local schedule = params.schedules[scheduleName];
+  local suspend = params.schedules_suspend[scheduleName];
+  kube._Object('batch/v1', 'CronJob', name) {
+    metadata+: {
+      namespace: params.namespace,
+      labels+: labels,
     },
-  },
-};
+    spec: {
+      schedule: schedule,
+      successfulJobsHistoryLimit: 3,
+      failedJobsHistoryLimit: 3,
+      jobTemplate: {
+        metadata: {
+          labels+: labels {
+            'cron-job-name': name,
+          },
+        },
+        spec: {
+          template: {
+            metadata: {
+              labels+: labels,
+            },
+            spec: {
+              restartPolicy: 'OnFailure',
+              initContainers: [],
+              containers: [],
+            } + jobSpec,
+          },
+        },
+      },
+      suspend: suspend,
+    },
+  };
 
 
 {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -134,7 +134,7 @@ local syncCategoriesContainer = {
 };
 
 local backfillCJ = function(queryName)
-  common.CronJob('backfill-%s' % escape(queryName), params.schedules.backfill, {
+  common.CronJob('backfill-%s' % escape(queryName), 'backfill', {
     initContainers: [
       checkMigrationContainer,
     ],
@@ -169,7 +169,7 @@ local backfillCJ = function(queryName)
     },
   };
 
-local checkCJ = common.CronJob('check-missing', params.schedules.check_missing, {
+local checkCJ = common.CronJob('check-missing', 'check_missing', {
   initContainers: [
     checkMigrationContainer,
     syncCategoriesContainer,
@@ -179,7 +179,7 @@ local checkCJ = common.CronJob('check-missing', params.schedules.check_missing, 
   ],
 });
 
-local invoiceCJ = common.CronJob('generate-invoices', params.schedules.invoice, {
+local invoiceCJ = common.CronJob('generate-invoices', 'invoice', {
   restartPolicy: 'Never',
   initContainers: [
     checkMigrationContainer,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -51,6 +51,15 @@ invoice: '0 10 1 * *'
 
 Dictionary managing the schedules of the periodic jobs (implemented as Kubernetes CronJobs).
 
+== `development_mode`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+This parameter allows to enable development mode for the component.
+The component prevents periodic jobs from being disabled, unless development mode is active.
+
 == `schedules_suspend`
 
 [horizontal]
@@ -68,6 +77,14 @@ This parameter allows users to selectively suspend one or more of the periodic j
 
 A suspended CronJob still exists on the cluster, but no new jobs are created based on the CronJob's schedule.
 
+[IMPORTANT]
+====
+Never use this parameter to disable CronJobs because they trigger alerts.
+Instead investigate why the alerts are triggered, and resolve the actual cause, such as missing data in the billing database.
+
+By disabling one or more of the periodic jobs, you'll most likely break the usage-based billing for the APPUiO Cloud instance.
+Breaking the usage-based billing will lead to lost income for the APPUiO Cloud instance.
+====
 
 == `database`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -49,7 +49,24 @@ check_missing: '30 8-14 * * *'
 invoice: '0 10 1 * *'
 ----
 
-Dictionary managing the schedules of the periodic jobs.
+Dictionary managing the schedules of the periodic jobs (implemented as Kubernetes CronJobs).
+
+== `schedules_suspend`
+
+[horizontal]
+type:: dictionary
+default::
++
+[source,yaml]
+----
+backfill: false
+check_missing: false
+invoice: false
+----
+
+This parameter allows users to selectively suspend one or more of the periodic jobs.
+
+A suspended CronJob still exists on the cluster, but no new jobs are created based on the CronJob's schedule.
 
 
 == `database`

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
@@ -83,6 +83,7 @@ spec:
           restartPolicy: OnFailure
   schedule: 15 * * * *
   successfulJobsHistoryLimit: 3
+  suspend: false
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -169,6 +170,7 @@ spec:
           restartPolicy: OnFailure
   schedule: 15 * * * *
   successfulJobsHistoryLimit: 3
+  suspend: false
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -255,3 +257,4 @@ spec:
           restartPolicy: OnFailure
   schedule: 15 * * * *
   successfulJobsHistoryLimit: 3
+  suspend: false

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
@@ -82,6 +82,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false
 ---
@@ -169,6 +170,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false
 ---
@@ -256,5 +258,6 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
@@ -95,3 +95,4 @@ spec:
           restartPolicy: OnFailure
   schedule: 30 8-14 * * *
   successfulJobsHistoryLimit: 3
+  suspend: false

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
@@ -94,5 +94,6 @@ spec:
               name: sync-categories
           restartPolicy: OnFailure
   schedule: 30 8-14 * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -124,5 +124,6 @@ spec:
               resources: {}
           restartPolicy: Never
   schedule: 0 10 1 * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/defaults/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -125,3 +125,4 @@ spec:
           restartPolicy: Never
   schedule: 0 10 1 * *
   successfulJobsHistoryLimit: 3
+  suspend: false

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/00_namespace.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/00_namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: appuio-cloud-reporting
+    openshift.io/cluster-monitoring: 'true'
+  name: appuio-cloud-reporting

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_db_secret.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_db_secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: reporting-db
+  name: reporting-db
+  namespace: appuio-cloud-reporting
+stringData:
+  password: letmein
+  username: appuio-cloud-reporting
+type: Opaque

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_erp_secret.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_erp_secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: erp-url
+  name: erp-url
+  namespace: appuio-cloud-reporting
+stringData:
+  url: http://enterprisey-enterprise
+type: Opaque

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_prom_secret.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/10_prom_secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: prom-url
+  name: prom-url
+  namespace: appuio-cloud-reporting
+stringData:
+  url: http://metrics
+type: Opaque

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
@@ -82,6 +82,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false
 ---
@@ -169,6 +170,7 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false
 ---
@@ -256,5 +258,6 @@ spec:
               name: check-migration
           restartPolicy: OnFailure
   schedule: 15 * * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/11_backfill.yaml
@@ -1,0 +1,260 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    query-name: appuio_cloud_loadbalancer
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: backfill-appuio-cloud-loadbalancer
+  name: backfill-appuio-cloud-loadbalancer
+  namespace: appuio-cloud-reporting
+spec:
+  failedJobsHistoryLimit: 768
+  jobTemplate:
+    metadata:
+      annotations:
+        query-name: appuio_cloud_loadbalancer
+      labels:
+        app.kubernetes.io/managed-by: commodore
+        app.kubernetes.io/name: appuio-cloud-reporting
+        app.kubernetes.io/part-of: syn
+        cron-job-name: backfill-appuio-cloud-loadbalancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: commodore
+            app.kubernetes.io/name: appuio-cloud-reporting
+            app.kubernetes.io/part-of: syn
+        spec:
+          containers:
+            - args:
+                - appuio-cloud-reporting report --begin=$(date -d "now -3 hours" -u
+                  +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds) --query-name=appuio_cloud_loadbalancer
+              command:
+                - sh
+                - -c
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: ACR_PROM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: prom-url
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: backfill
+              resources: {}
+          initContainers:
+            - args:
+                - migrate
+                - --show-pending
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-migration
+          restartPolicy: OnFailure
+  schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    query-name: appuio_cloud_memory
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: backfill-appuio-cloud-memory
+  name: backfill-appuio-cloud-memory
+  namespace: appuio-cloud-reporting
+spec:
+  failedJobsHistoryLimit: 768
+  jobTemplate:
+    metadata:
+      annotations:
+        query-name: appuio_cloud_memory
+      labels:
+        app.kubernetes.io/managed-by: commodore
+        app.kubernetes.io/name: appuio-cloud-reporting
+        app.kubernetes.io/part-of: syn
+        cron-job-name: backfill-appuio-cloud-memory
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: commodore
+            app.kubernetes.io/name: appuio-cloud-reporting
+            app.kubernetes.io/part-of: syn
+        spec:
+          containers:
+            - args:
+                - appuio-cloud-reporting report --begin=$(date -d "now -3 hours" -u
+                  +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds) --query-name=appuio_cloud_memory
+              command:
+                - sh
+                - -c
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: ACR_PROM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: prom-url
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: backfill
+              resources: {}
+          initContainers:
+            - args:
+                - migrate
+                - --show-pending
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-migration
+          restartPolicy: OnFailure
+  schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    query-name: appuio_cloud_persistent_storage
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: backfill-appuio-cloud-persistent-storage
+  name: backfill-appuio-cloud-persistent-storage
+  namespace: appuio-cloud-reporting
+spec:
+  failedJobsHistoryLimit: 768
+  jobTemplate:
+    metadata:
+      annotations:
+        query-name: appuio_cloud_persistent_storage
+      labels:
+        app.kubernetes.io/managed-by: commodore
+        app.kubernetes.io/name: appuio-cloud-reporting
+        app.kubernetes.io/part-of: syn
+        cron-job-name: backfill-appuio-cloud-persistent-storage
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: commodore
+            app.kubernetes.io/name: appuio-cloud-reporting
+            app.kubernetes.io/part-of: syn
+        spec:
+          containers:
+            - args:
+                - appuio-cloud-reporting report --begin=$(date -d "now -3 hours" -u
+                  +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds) --query-name=appuio_cloud_persistent_storage
+              command:
+                - sh
+                - -c
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: ACR_PROM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: prom-url
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: backfill
+              resources: {}
+          initContainers:
+            - args:
+                - migrate
+                - --show-pending
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-migration
+          restartPolicy: OnFailure
+  schedule: 15 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
@@ -94,5 +94,6 @@ spec:
               name: sync-categories
           restartPolicy: OnFailure
   schedule: 30 8-14 * * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: true

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/12_check_missing.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: check-missing
+  name: check-missing
+  namespace: appuio-cloud-reporting
+spec:
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: commodore
+        app.kubernetes.io/name: appuio-cloud-reporting
+        app.kubernetes.io/part-of: syn
+        cron-job-name: check-missing
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: commodore
+            app.kubernetes.io/name: appuio-cloud-reporting
+            app.kubernetes.io/part-of: syn
+        spec:
+          containers:
+            - args:
+                - check_missing
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-missing
+              resources: {}
+          initContainers:
+            - args:
+                - migrate
+                - --show-pending
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-migration
+            - args:
+                - sync
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: OA_ODOO_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: erp-url
+              image: ghcr.io/vshn/appuio-odoo-adapter:v1.5.0
+              name: sync-categories
+          restartPolicy: OnFailure
+  schedule: 30 8-14 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: true

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -1,0 +1,128 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: generate-invoices
+  name: generate-invoices
+  namespace: appuio-cloud-reporting
+spec:
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: commodore
+        app.kubernetes.io/name: appuio-cloud-reporting
+        app.kubernetes.io/part-of: syn
+        cron-job-name: generate-invoices
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: commodore
+            app.kubernetes.io/name: appuio-cloud-reporting
+            app.kubernetes.io/part-of: syn
+        spec:
+          containers:
+            - args:
+                - appuio-odoo-adapter invoice --year=$(date -d "now -1 months" -u
+                  +"%Y") --month=$(date -d "now -1 months" -u +"%-m")
+              command:
+                - sh
+                - -c
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: OA_ODOO_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: erp-url
+              image: ghcr.io/vshn/appuio-odoo-adapter:v1.5.0
+              name: invoice
+              resources: {}
+          initContainers:
+            - args:
+                - migrate
+                - --show-pending
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-migration
+            - args:
+                - sync
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+                - name: OA_ODOO_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: erp-url
+              image: ghcr.io/vshn/appuio-odoo-adapter:v1.5.0
+              name: sync-categories
+            - args:
+                - check_missing
+              env:
+                - name: password
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: reporting-db
+                - name: username
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: reporting-db
+                - name: ACR_DB_URL
+                  value: postgres://$(username):$(password)@db.example.com:5432/appuio-cloud-reporting?
+                - name: OA_DB_URL
+                  value: $(ACR_DB_URL)
+              image: ghcr.io/appuio/appuio-cloud-reporting:v0.7.0
+              name: check-missing
+              resources: {}
+          restartPolicy: Never
+  schedule: 0 10 1 * *
+  successfulJobsHistoryLimit: 3
+  suspend: true

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/20_invoice.yaml
@@ -124,5 +124,6 @@ spec:
               resources: {}
           restartPolicy: Never
   schedule: 0 10 1 * *
+  startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 3
   suspend: true

--- a/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/50_alerts.yaml
+++ b/tests/golden/suspended-cronjobs/appuio-cloud-reporting/appuio-cloud-reporting/50_alerts.yaml
@@ -1,0 +1,63 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud-reporting
+    app.kubernetes.io/part-of: syn
+    name: appuio-cloud-reporting
+  name: appuio-cloud-reporting
+  namespace: appuio-cloud-reporting
+spec:
+  groups:
+    - name: appuio-cloud-reporting.alerts
+      rules:
+        - alert: APPUiOCloudInvoiceGenerationFailed
+          annotations:
+            description: APPUiO Cloud Invoice generation in Odoo failed.
+            message: APPUiO Cloud Invoice generation in Odoo failed.
+            runbook_url: https://hub.syn.tools/appuio-cloud-reporting/runbooks/APPUiOCloudInvoiceGenerationFailed.html
+            summary: APPUiO Cloud Invoice generation in Odoo failed.
+          expr: 'kube_job_failed{job="kube-state-metrics",namespace="appuio-cloud-reporting",job_name=~"generate-invoices-.*"}
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: appuio-cloud-reporting
+        - alert: APPUiOCloudReportingDatabaseBackfillingFailed
+          annotations:
+            description: APPUiO Cloud Reporting backfilling metrics into reporting
+              database failed.
+            message: APPUiO Cloud Reporting backfilling metrics into reporting database
+              failed.
+            runbook_url: https://hub.syn.tools/appuio-cloud-reporting/runbooks/APPUiOCloudReportingDatabaseBackfillingFailed.html
+            summary: APPUiO Cloud Reporting backfilling metrics into reporting database
+              failed.
+          expr: 'kube_job_failed{job="kube-state-metrics",namespace="appuio-cloud-reporting",job_name=~"backfill-.*"}
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: appuio-cloud-reporting
+        - alert: APPUiOCloudReportingMissingData
+          annotations:
+            description: APPUiO Cloud Reporting is missing ERP link `target` data.
+            message: APPUiO Cloud Reporting is missing ERP link `target` data.
+            runbook_url: https://hub.syn.tools/appuio-cloud-reporting/runbooks/APPUiOCloudReportingMissingData.html
+            summary: APPUiO Cloud Reporting is missing ERP link `target` data.
+          expr: '(kube_job_failed{job="kube-state-metrics",namespace="appuio-cloud-reporting",job_name=~"check-missing-.*"}
+            * scalar((days_in_month() - day_of_month()) <bool 7)) > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: appuio-cloud-reporting

--- a/tests/suspended-cronjobs.yml
+++ b/tests/suspended-cronjobs.yml
@@ -10,6 +10,7 @@ parameters:
     erp_adapter:
       url: http://enterprisey-enterprise
 
+    development_mode: true
     schedules_suspend:
       check_missing: true
       invoice: true

--- a/tests/suspended-cronjobs.yml
+++ b/tests/suspended-cronjobs.yml
@@ -1,0 +1,15 @@
+parameters:
+  appuio_cloud_reporting:
+    database:
+      host: db.example.com
+      password: letmein
+
+    prometheus:
+      url: http://metrics
+
+    erp_adapter:
+      url: http://enterprisey-enterprise
+
+    schedules_suspend:
+      check_missing: true
+      invoice: true


### PR DESCRIPTION
CronJobs can only be suspended if the component parameter `development_mode` is set to `true`. Otherwise, trying to disable a CronJob will result in a compilation error.

We set `startingDeadlineSeconds` to ensure that new jobs will be scheduled if the cronjob is unsuspended after a long period of being suspended. This is required because any jobs that would have been scheduled while the CronJob is suspended count as missed and without `startingDeadlineSeconds` set, the CronJob controller will not schedule new jobs if >100 jobs were missed. See the following upstream documentation:

* https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#suspend
* https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
