### PR TITLE
Enable multi-instance for this component

### DIFF
--- a/class/appuio-cloud-reporting.yml
+++ b/class/appuio-cloud-reporting.yml
@@ -8,4 +8,4 @@ parameters:
       - input_paths:
           - appuio-cloud-reporting/component/main.jsonnet
         input_type: jsonnet
-        output_path: appuio-cloud-reporting/
+        output_path: ${_instance}/

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,8 @@
 parameters:
   appuio_cloud_reporting:
-    =_metadata: {}
-    namespace: appuio-cloud-reporting
+    =_metadata:
+      multi_instance: true
+    namespace: ${_instance}
 
     images:
       reporting:

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -2,9 +2,10 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appuio_cloud_reporting;
 local argocd = import 'lib/argocd.libjsonnet';
+local instance = inv.parameters._instance;
 
-local app = argocd.App('appuio-cloud-reporting', params.namespace);
+local app = argocd.App(instance, params.namespace);
 
 {
-  'appuio-cloud-reporting': app,
+  [instance]: app,
 }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,4 +2,6 @@
 
 appuio-cloud-reporting is a Commodore component to manage appuio-cloud-reporting.
 
+appuio-cloud-reporting supports instantiating the component multiple times (see Project Syn documentation for details).
+
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,7 +6,7 @@ The parent key for all of the following parameters is `appuio_cloud_reporting`.
 
 [horizontal]
 type:: string
-default:: `appuio-cloud-reporting`
+default:: `${_instance}`
 
 The namespace in which to deploy this component.
 


### PR DESCRIPTION
This change allows the component to be instantiated multiple times. Each instance is deployed into a separate namespace.

Implements OCP-620




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
